### PR TITLE
feat: add Llama client

### DIFF
--- a/engine/llm.js
+++ b/engine/llm.js
@@ -1,0 +1,27 @@
+const fetch = global.fetch || require('node-fetch');
+
+async function askLlama(prompt) {
+  try {
+    const response = await fetch('http://99.243.100.183:50093/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'llama3',
+        prompt: prompt,
+        stream: false
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error querying Llama:', error);
+    throw error;
+  }
+}
+
+module.exports = { askLlama };


### PR DESCRIPTION
## Summary
- add helper to query local Llama model via REST API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893559bf1a48329b94730a993a503f8