### PR TITLE
docs: log start of LLaMA backend integration

### DIFF
--- a/project-notes/dev-log.md
+++ b/project-notes/dev-log.md
@@ -1,0 +1,6 @@
+## ✅ 2025-08-06 – LLaMA Backend Integration Begins
+
+- Created `engine/llm.js` to connect backend to live LLaMA 3.1 8B model hosted on Vast.ai
+- Verified Ollama API running on port 50093
+- Logged setup for repeatability and future upgrades
+


### PR DESCRIPTION
## Summary
- log kickoff of LLaMA 3.1 8B backend integration

## Testing
- `npm test` (fails: ENOENT cannot read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68935711ba54832984d0aa24410b844e