### PR TITLE
docs: log LLaMA API endpoint

### DIFF
--- a/project-notes/dev-log.md
+++ b/project-notes/dev-log.md
@@ -4,3 +4,7 @@
 - Verified Ollama API running on port 50093
 - Logged setup for repeatability and future upgrades
 
+## ✅ 2025-08-06 – LLaMA API Endpoint
+
+- Added `routes/llm.js` to expose `/llm` POST route
+- Frontend or tools can now send prompts to LLaMA backend


### PR DESCRIPTION
## Summary
- log addition of `routes/llm.js` POST route for prompting LLaMA backend

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689359e78a64832983aa1100890c602d