### PR TITLE
docs: log backend server integration

### DIFF
--- a/project-notes/dev-log.md
+++ b/project-notes/dev-log.md
@@ -8,3 +8,11 @@
 
 - Added `routes/llm.js` to expose `/llm` POST route
 - Frontend or tools can now send prompts to LLaMA backend
+
+## ✅ 2025-08-06 – Backend Server + LLaMA API
+
+- Created `server.js` to run the Express backend on port 3001
+- Connected route handler from `routes/llm.js` to accept POST prompts
+- Backend can now receive prompts from the frontend and pass them to the LLaMA 3.1 model via Ollama
+- Confirmed Ollama is still accessible at `http://99.243.100.183:50093`
+


### PR DESCRIPTION
## Summary
- document new Express server and LLaMA API connection in project dev log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68935cb224ac8329ace766217cf5a69a