### PR TITLE
feat: add development launcher script

### DIFF
--- a/launch-dev.js
+++ b/launch-dev.js
@@ -1,0 +1,66 @@
+const { spawn } = require('child_process');
+const net = require('net');
+const path = require('path');
+
+// Utility to check if a TCP port is already in use
+function isPortInUse(port) {
+  return new Promise((resolve) => {
+    const tester = net.createServer()
+      .once('error', err => (err.code === 'EADDRINUSE' ? resolve(true) : resolve(false)))
+      .once('listening', () => tester.once('close', () => resolve(false)).close())
+      .listen(port);
+  });
+}
+
+// Spawn a child process and mirror its output in the current terminal
+function run(cmd, args, options = {}) {
+  return spawn(cmd, args, { stdio: 'inherit', shell: true, ...options });
+}
+
+(async () => {
+  const processes = [];
+
+  // Establish SSH tunnel to Vast.ai instance if not already running
+  if (!(await isPortInUse(11111))) {
+    const ssh = run('ssh', ['-N', '-L', '11111:localhost:11434', '-p', '50015', 'root@99.243.100.183']);
+    processes.push(ssh);
+  } else {
+    console.log('🔁 SSH tunnel already running on port 11111');
+  }
+
+  // Start backend server (server.js) if port 3001 is free
+  if (!(await isPortInUse(3001))) {
+    const backend = run('node', ['server.js']);
+    processes.push(backend);
+  } else {
+    console.log('🔁 Backend server already running on port 3001');
+  }
+
+  // Start frontend dev server in ../holly-frontend if port 5173 is free
+  if (!(await isPortInUse(5173))) {
+    const frontend = run('npm', ['run', 'dev'], { cwd: path.resolve(__dirname, '../holly-frontend') });
+    processes.push(frontend);
+  } else {
+    console.log('🔁 Frontend dev server already running on port 5173');
+  }
+
+  // Ensure all spawned processes are terminated if this script exits
+  const cleanup = () => {
+    processes.forEach(proc => {
+      if (!proc.killed) {
+        proc.kill('SIGTERM');
+      }
+    });
+  };
+
+  process.on('SIGINT', () => {
+    cleanup();
+    process.exit();
+  });
+  process.on('SIGTERM', () => {
+    cleanup();
+    process.exit();
+  });
+  process.on('exit', cleanup);
+})();
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "holly-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "launch": "node launch-dev.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add launch-dev.js to open SSH tunnel and start back/front-end servers
- wire up `npm run launch` script in package.json

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893935a79c88329a780c4dc23b55d67