### PR TITLE
Add streaming TTS route using Coqui

### DIFF
--- a/routes/tts.js
+++ b/routes/tts.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const router = express.Router();
+const { spawn } = require('child_process');
+const fs = require('fs');
+
+router.post('/', (req, res) => {
+  const { text } = req.body;
+  if (!text) {
+    return res.status(400).json({ error: 'Text is required' });
+  }
+
+  const python = spawn('python3', ['tts.py', text]);
+  let stdout = '';
+  let stderr = '';
+
+  python.stdout.on('data', (data) => {
+    stdout += data.toString();
+  });
+
+  python.stderr.on('data', (data) => {
+    stderr += data.toString();
+  });
+
+  python.on('error', () => {
+    return res.status(500).json({ error: 'TTS script not found' });
+  });
+
+  python.on('close', (code) => {
+    if (code !== 0) {
+      console.error(stderr);
+      return res.status(500).json({ error: 'TTS generation failed' });
+    }
+
+    const filePath = stdout.trim().split('\n').slice(-1)[0];
+    res.setHeader('Content-Type', 'audio/mpeg');
+    const stream = fs.createReadStream(filePath);
+
+    stream.on('error', (err) => {
+      console.error(err);
+      res.status(500).end();
+    });
+
+    stream.pipe(res);
+
+    req.on('close', () => {
+      python.kill();
+      stream.destroy();
+    });
+
+    stream.on('close', () => {
+      fs.unlink(filePath, () => {});
+    });
+  });
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -15,6 +15,10 @@ app.use(express.json());
 const llmRouter = require('./routes/llm.js');
 app.use('/llm', llmRouter);
 
+// Route for TTS endpoint
+const ttsRouter = require('./routes/tts.js');
+app.use('/tts', ttsRouter);
+
 // Start the server
 const PORT = 3001;
 app.listen(PORT, () => {

--- a/tts.py
+++ b/tts.py
@@ -1,0 +1,21 @@
+import sys
+import os
+from TTS.api import TTS
+from pydub import AudioSegment
+
+def main():
+    text = sys.argv[1] if len(sys.argv) > 1 else "Hello there"
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    wav_path = os.path.join(base_dir, 'output.wav')
+    mp3_path = os.path.join(base_dir, 'output.mp3')
+
+    tts = TTS(model_name="tts_models/en/ljspeech/tacotron2-DDC", progress_bar=False, gpu=False)
+    tts.tts_to_file(text=text, file_path=wav_path)
+
+    audio = AudioSegment.from_wav(wav_path)
+    audio.export(mp3_path, format='mp3')
+
+    print(os.path.abspath(mp3_path))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `/tts` route that spawns a python Coqui TTS script and streams back MP3 audio
- implement `tts.py` using Coqui TTS and pydub to produce `output.mp3`
- wire the new route into the Express server

## Testing
- `python3 -m pip install TTS pydub`
- `python3 tts.py "hello there"` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `apt-get update && apt-get install -y ffmpeg`
- `npm test` *(fails: Missing script "test")*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68939f6bc4288329b55a1a49767ab20d