### PR TITLE
Ensure remote Ollama server starts with SSH tunnel

### DIFF
--- a/launch-dev.js
+++ b/launch-dev.js
@@ -24,6 +24,12 @@ function run(cmd, args, options = {}) {
   if (!(await isPortInUse(11111))) {
     const ssh = run('ssh', ['-N', '-L', '11111:localhost:11434', '-p', '50015', 'root@99.243.100.183']);
     processes.push(ssh);
+
+    // Ensure remote Ollama server is running
+    const remoteCmd =
+      "if ! ss -tuln | grep -q ':11434'; then " +
+      'OLLAMA_HOST=0.0.0.0:11434 nohup ollama serve >/tmp/ollama.log 2>&1 & fi';
+    run('ssh', [`-p 50015 root@99.243.100.183 "${remoteCmd}"`]);
   } else {
     console.log('🔁 SSH tunnel already running on port 11111');
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "launch": "node launch-dev.js"
+    "launch": "node launch-dev.js",
+    "launch-dev": "node launch-dev.js"
   }
 }


### PR DESCRIPTION
## Summary
- Start remote `ollama serve` on Vast.ai instance when SSH tunnel is created, only if port 11434 is not already listening.
- Check for existing remote server and launch it in the background without blocking main script.
- Expose launch scripts in `package.json` for running the dev environment.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68939888db4c8329bd9bd217e6b907d9