### PR TITLE
Stream LLM audio responses

### DIFF
--- a/python/stream_tts.py
+++ b/python/stream_tts.py
@@ -1,0 +1,38 @@
+"""Stream text-to-speech audio.
+
+This script reads lines of text from stdin. For each line received it
+synthesizes speech using Coqui TTS and writes the resulting MP3 bytes to
+stdout. The script is intended to be used as a subprocess where the
+caller pipes incremental text to stdin and consumes audio from stdout.
+"""
+
+import io
+import sys
+
+from TTS.api import TTS
+from pydub import AudioSegment
+
+
+tts = TTS(
+    model_name="tts_models/en/ljspeech/tacotron2-DDC",
+    progress_bar=False,
+    gpu=False,
+)
+
+for line in sys.stdin:
+    text = line.strip()
+    if not text:
+        continue
+
+    # Generate audio for the current chunk of text
+    wav = tts.tts(text)
+    audio = AudioSegment(
+        wav.tobytes(),
+        frame_rate=tts.output_sample_rate,
+        sample_width=2,
+        channels=1,
+    )
+    buf = io.BytesIO()
+    audio.export(buf, format="mp3")
+    sys.stdout.buffer.write(buf.getvalue())
+    sys.stdout.flush()

--- a/routes/llm.js
+++ b/routes/llm.js
@@ -1,16 +1,81 @@
 const express = require('express');
-const router = express.Router();
+const cors = require('cors');
+const fetch = global.fetch || require('node-fetch');
+const { spawn } = require('child_process');
+const path = require('path');
 
-const { askLlama } = require('../engine/llm.js');
+const router = express.Router();
+router.use(cors());
 
 router.post('/', async (req, res) => {
   const { prompt } = req.body;
+  if (!prompt) {
+    return res.status(400).json({ error: 'Prompt is required' });
+  }
+
+  res.setHeader('Content-Type', 'audio/mpeg');
+  res.setHeader('Transfer-Encoding', 'chunked');
+  res.setHeader('Trailer', 'X-Transcript');
+
+  const scriptPath = path.join(__dirname, '..', 'python', 'stream_tts.py');
+  const python = spawn('python3', [scriptPath]);
+
+  let closed = false;
+  req.on('close', () => {
+    closed = true;
+    python.kill();
+  });
+
+  python.stdout.on('data', (chunk) => {
+    res.write(chunk);
+  });
+
+  python.stderr.on('data', (data) => {
+    console.error('TTS error:', data.toString());
+  });
+
+  let textBuffer = '';
 
   try {
-    const response = await askLlama(prompt);
-    res.json(response);
+    const response = await fetch('http://localhost:11111/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'llama3',
+        prompt: prompt,
+        stream: true,
+      }),
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value);
+      textBuffer += chunk;
+      python.stdin.write(chunk + '\n');
+    }
+
+    python.stdin.end();
+
+    python.on('close', () => {
+      if (!closed) {
+        res.addTrailers({ 'X-Transcript': textBuffer });
+        res.end();
+      }
+    });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    console.error('Error querying Llama:', error.message);
+    python.kill();
+    if (!closed) {
+      res.status(500).end();
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- stream LLM text through a Python TTS subprocess
- deliver MP3 audio chunks with X-Transcript trailer

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6893c03246cc8329818f7a60bbbe4225