### PR TITLE
fix: run launch scripts with node

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "launch": "./launch-dev.js",
-    "launch-dev": "./launch-dev.js"
+    "launch": "node launch-dev.js",
+    "launch-dev": "node launch-dev.js"
   },
   "dependencies": {
     "express": "^4.21.2",


### PR DESCRIPTION
## Summary
- ensure launch scripts run via `node` for cross-platform support

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893d03eb1148329bedbb4c0e56cc26b