### PR TITLE
fix streaming audio headers for TTS

### DIFF
--- a/routes/llm.js
+++ b/routes/llm.js
@@ -21,9 +21,12 @@ router.post('/', async (req, res) => {
     currentSession.abort();
   }
 
-  res.setHeader('Content-Type', 'audio/mpeg');
-  res.setHeader('Transfer-Encoding', 'chunked');
-  res.setHeader('Trailer', 'X-Transcript');
+  res.writeHead(200, {
+    'Content-Type': 'audio/mpeg',
+    'Transfer-Encoding': 'chunked',
+    'Connection': 'keep-alive',
+    'Trailer': 'X-Transcript',
+  });
 
   const scriptPath = path.join(__dirname, '..', 'python', 'tts.py');
   const abortController = new AbortController();


### PR DESCRIPTION
## Summary
- ensure TTS stream uses proper audio/mpeg chunked response headers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893d29520d483299a83bf6d55c4e7d7