### PR TITLE
feat: sync repos before launching

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "launch": "node launch-dev.js",
+    "launch": "bash scripts/launch.sh",
     "launch-dev": "node launch-dev.js"
   },
   "dependencies": {

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -euo pipefail
+
+# Update local repository
+echo "Syncing local repository..."
+if ! git pull origin main; then
+  echo "Failed to update local repository." >&2
+  exit 1
+fi
+
+# Update Vast.ai instance
+VAST_IP="<YOUR_VAST_IP>"
+echo "Syncing Vast.ai repository at ${VAST_IP}..."
+if ! ssh -p 50015 "root@${VAST_IP}" 'cd /root/holly-backend && git reset --hard && git pull origin main'; then
+  echo "Failed to update Vast.ai repository." >&2
+  exit 1
+fi
+
+# Launch development server
+echo "Starting development environment..."
+node launch-dev.js


### PR DESCRIPTION
## Summary
- add launch script to sync local and Vast.ai repos before running dev server
- wire npm launch command to new script

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68947770bab483298118c50a70a25c29