### PR TITLE
fix: support npm spawn on Windows

### DIFF
--- a/launch-dev.js
+++ b/launch-dev.js
@@ -8,6 +8,9 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 
+// On Windows the npm executable is npm.cmd
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
 // Ensure we're running from the backend directory
 const backendDir = path.resolve(__dirname);
 process.chdir(backendDir);
@@ -49,7 +52,7 @@ try {
 
 if (pkgHash !== lastHash) {
   console.log('📦 package.json changed, running npm install...');
-  runSync('npm', ['install']);
+  runSync(npmCmd, ['install']);
   fs.writeFileSync(hashFile, pkgHash);
 } else {
   console.log('📦 Dependencies up to date, skipping npm install.');
@@ -104,7 +107,7 @@ function run(cmd, args, options = {}) {
   // Start frontend dev server in ../holly-frontend if port 5173 is free
   if (!(await isPortInUse(5173))) {
     console.log('🚀 Starting frontend dev server...');
-    const frontend = run('npm', ['run', 'dev'], { cwd: path.resolve(__dirname, '../holly-frontend') });
+    const frontend = run(npmCmd, ['run', 'dev'], { cwd: path.resolve(__dirname, '../holly-frontend') });
     processes.push(frontend);
   } else {
     console.log('🔁 Frontend dev server already running on port 5173');


### PR DESCRIPTION
## Summary
- ensure launch script uses `npm.cmd` on Windows
- run frontend dev server with cross-platform npm command

## Testing
- `node launch-dev.js` *(fails: fatal: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_6894868ddde4832980f203539ab2f1fe