### PR TITLE
Fix Windows shell parsing for SSH commands

### DIFF
--- a/launch-dev.js
+++ b/launch-dev.js
@@ -43,7 +43,7 @@ const remotePullCmd = `
     echo "✅ Remote backend already up to date.";
   fi
 `.trim();
-runSync('ssh', ['-p', '50015', 'root@99.243.100.183', remotePullCmd]);
+runSync('ssh', ['-p', '50015', 'root@99.243.100.183', remotePullCmd], { shell: false });
 
 // Compute package.json hash to detect changes
 const pkgPath = path.join(backendDir, 'package.json');
@@ -93,7 +93,7 @@ function run(cmd, args, options = {}) {
 
   // Establish SSH tunnel to Vast.ai instance if not already running
   if (!(await isPortInUse(11111))) {
-      const ssh = run('ssh', ['-N', '-L', '11111:localhost:11434', '-p', '50015', 'root@99.243.100.183']);
+      const ssh = run('ssh', ['-N', '-L', '11111:localhost:11434', '-p', '50015', 'root@99.243.100.183'], { shell: false });
     processes.push(ssh);
 
     // Ensure remote Ollama server is running
@@ -102,7 +102,7 @@ function run(cmd, args, options = {}) {
         'OLLAMA_HOST=0.0.0.0:11434 nohup ollama serve >/tmp/ollama.log 2>&1 &',
         'fi'
       ].join(' ');
-      run('ssh', ['-p', '50015', 'root@99.243.100.183', remoteCmd]);
+      run('ssh', ['-p', '50015', 'root@99.243.100.183', remoteCmd], { shell: false });
   } else {
     console.log('🔁 SSH tunnel already running on port 11111');
   }


### PR DESCRIPTION
## Summary
- Avoid Windows command interpreter when executing SSH commands in `launch-dev.js`
- Pass `{ shell: false }` to SSH spawns so Bash syntax in remote commands isn't parsed by `cmd.exe`

## Testing
- `node launch-dev.js` *(fails: 'origin' does not appear to be a git repository)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894894b4794832998a170c2832d1aef