### PR TITLE
Default to streaming TTS with JSON debug path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "launch-dev": "node launch-dev.js",
     "tunnel": "/usr/local/bin/cloudflared tunnel --config .cloudflared/config.yml run holly-backend",
     "pm2": "pm2 start launch-dev.js --name holly-backend && pm2 save",
+    "pm2:restart": "pm2 restart holly-backend && pm2 restart cloudflared && pm2 restart ollama && pm2 save",
     "test": "echo 'OK'"
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -3,10 +3,8 @@ const cors = require('cors');
 
 const app = express();
 
-// Enable CORS from local frontend dev servers (5173 or 5174)
-app.use(cors({
-  origin: ['http://localhost:5173', 'http://localhost:5174']
-}));
+// Enable CORS for any requesting origin
+app.use(cors({ origin: true }));
 
 // Parse incoming JSON
 app.use(express.json());
@@ -14,6 +12,11 @@ app.use(express.json());
 // Route for TTS endpoint
 const ttsRouter = require('./routes/tts.js');
 app.use('/tts', ttsRouter);
+
+// Simple health check
+app.get('/health', (req, res) => {
+  res.status(200).json({ ok: true });
+});
 
 
 // Start the server


### PR DESCRIPTION
## Summary
- Allow any origin via CORS and expose `/health` endpoint for uptime checks
- Default `/tts` to stream MP3 audio while providing `json: true` escape hatch
- Add pm2 restart helper script
- Update launch script to ensure remote holly-backend, Ollama, and Cloudflare services stay active under PM2

## Testing
- `npm test`
- `node --check launch-dev.js`


------
https://chatgpt.com/codex/tasks/task_e_6895c16726a083298812ec1a76cf01c6