### PR TITLE
Log TTS request body for easier JSON/MP3 debugging

### DIFF
--- a/routes/tts.js
+++ b/routes/tts.js
@@ -14,6 +14,8 @@ router.post('/', async (req, res) => {
   const { prompt } = req.body;
   const json = req.body.json === true;
 
+  // Log entire request body to help debug unexpected fields
+  console.log('TTS request body', req.body);
   console.log('TTS request received', {
     json,
     promptLength: prompt ? prompt.length : 0,


### PR DESCRIPTION
## Summary
- log the full request body in `/tts` to help diagnose when `json` is sent
- maintain behaviour of streaming MP3 unless `json: true`

## Testing
- `curl -i -X POST http://localhost:3001/tts -H "Content-Type: application/json" -d '{"prompt":"Hello"}' --max-time 10` *(times out – Llama server unavailable)*
- Observed server logs: `TTS request body { prompt: 'Hello' }`

------
https://chatgpt.com/codex/tasks/task_e_6895c80894348329b7027b9074467a78