### PR TITLE
Add STT transcription endpoint and deployment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["bash", "start.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+python-multipart
+faster-whisper
+torch
+ffmpeg-python

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+uvicorn main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add /listen endpoint backed by faster-whisper for speech-to-text
- load GPU whisper model at startup and enable CORS
- include Dockerfile, requirements, and start script for container deployment

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6895f3585da08329afcf7cb3ae5f75c5