### PR TITLE
Add global CORS middleware and request logging

### DIFF
--- a/routes/tts.js
+++ b/routes/tts.js
@@ -1,11 +1,9 @@
 const express = require('express');
-const cors = require('cors');
 const fetch = global.fetch || require('node-fetch');
 const { spawn } = require('child_process');
 const path = require('path');
 
 const router = express.Router();
-router.use(cors());
 
 let currentSession = null;
 

--- a/server.js
+++ b/server.js
@@ -3,14 +3,25 @@ const cors = require('cors');
 
 const app = express();
 
-// CORS: allow localhost dev + your Cloudflare domain
+// reflect any origin; allow common headers/methods
 app.use(cors({
-  origin: [
-    'http://localhost:5173',
-    'http://localhost:5174',
-    'https://api.hollyai.xyz',
-  ],
+  origin: (origin, cb) => cb(null, true),
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  credentials: false,
 }));
+
+// ensure all preflights succeed
+app.options('*', cors());
+
+app.use((req, res, next) => {
+  const start = Date.now();
+  res.on('finish', () => {
+    const ms = Date.now() - start;
+    console.log(`[${new Date().toISOString()}] ${req.method} ${req.originalUrl} ${res.statusCode} origin=${req.headers.origin || '-'} ${ms}ms`);
+  });
+  next();
+});
 
 app.use(express.json());
 


### PR DESCRIPTION
## Summary
- Allow any origin with standard headers and methods using global CORS middleware
- Add simple request logger and keep existing /health endpoint
- Remove per-route CORS from TTS router to rely on global headers

## Testing
- `npm test`
- `curl -i -H 'Origin: http://example.com' http://localhost:3001/health`
- `curl -i -X OPTIONS -H 'Origin: http://localhost:5173' -H 'Access-Control-Request-Method: POST' http://localhost:3001/tts`
- `curl -i -X POST -H 'Origin: http://localhost:5173' -H 'Content-Type: application/json' -d '{}' http://localhost:3001/tts`


------
https://chatgpt.com/codex/tasks/task_e_689607af28388329bec7c29430427459