### PR TITLE
feat: add gpu-aware tts diagnostics and warmup

### DIFF
--- a/python/tts_server.py
+++ b/python/tts_server.py
@@ -2,6 +2,7 @@ import io
 import wave
 import logging
 import os
+import time
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response, JSONResponse
 from pydantic import BaseModel
@@ -12,11 +13,17 @@ try:  # Optional heavy dependency
 except Exception:  # pragma: no cover
     CoquiTTS = None
 
+try:  # torch is optional
+    import torch
+except Exception:  # pragma: no cover
+    torch = None
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("tts_server")
 
 MODEL_ID = os.getenv("TTS_MODEL", "tts_models/en/ljspeech/tacotron2-DDC")
+TTS_DEVICE = os.getenv("TTS_DEVICE", "auto").lower()
 
 
 def _init_tts():
@@ -29,7 +36,9 @@ def _init_tts():
         return None
 
 
+init_start = time.perf_counter()
 tts = _init_tts()
+init_ms = int((time.perf_counter() - init_start) * 1000)
 
 if tts is None:
     class DummyTTS:
@@ -46,9 +55,40 @@ if tts is None:
 
     tts = DummyTTS()
 
-DEVICE = getattr(tts, "device", "cpu")
+want_cuda = TTS_DEVICE in ("auto", "cuda")
+cuda_avail = bool(torch and torch.cuda.is_available())
+device_used = "cpu"
+if want_cuda and cuda_avail and hasattr(tts, "to"):
+    try:
+        tts.to("cuda")
+        device_used = "cuda"
+    except Exception as ex:  # pragma: no cover
+        logger.warning("Could not move TTS to CUDA: %s", ex)
+elif TTS_DEVICE == "cuda" and not cuda_avail:
+    logger.warning("CUDA requested but unavailable, using CPU")
+tts.device = device_used
+
 DEFAULT_SR = int(getattr(tts, "output_sample_rate", getattr(tts, "sample_rate", 22050)))
-logger.info("TTS model=%s device=%s sample_rate=%s", MODEL_ID, DEVICE, DEFAULT_SR)
+
+torch_version = getattr(torch, "__version__", "none")
+cuda_count = torch.cuda.device_count() if cuda_avail and torch else 0
+current_device = torch.cuda.current_device() if cuda_avail and torch else None
+device_name = (
+    torch.cuda.get_device_name(current_device) if cuda_avail and torch else None
+)
+
+logger.info(
+    "TTS init model=%s device=%s torch=%s cuda_avail=%s cuda_count=%s current_device=%s device_name=%s sr=%s init_ms=%s",
+    MODEL_ID,
+    device_used,
+    torch_version,
+    cuda_avail,
+    cuda_count,
+    current_device,
+    device_name,
+    DEFAULT_SR,
+    init_ms,
+)
 
 
 app = FastAPI()
@@ -60,11 +100,37 @@ class SpeakRequest(BaseModel):
 
 
 def synthesize(text: str) -> np.ndarray:
-    wav = tts.tts(text)
-    wav = np.asarray(wav, dtype=np.float32)
+    if torch is not None:
+        with torch.inference_mode():
+            if getattr(tts, "device", "cpu") == "cuda":
+                try:
+                    from torch.cuda.amp import autocast
+
+                    with autocast():
+                        y = tts.tts(text)
+                except Exception as ex:  # pragma: no cover
+                    logger.warning("AMP disabled due to error: %s", ex)
+                    y = tts.tts(text)
+            else:
+                y = tts.tts(text)
+    else:
+        y = tts.tts(text)
+
+    wav = np.asarray(y, dtype=np.float32)
     if wav.ndim > 1:
         wav = np.mean(wav, axis=1).astype(np.float32)
     return wav
+
+
+WARMED_UP = False
+try:
+    warm_start = time.perf_counter()
+    synthesize("warmup")
+    warmup_ms = int((time.perf_counter() - warm_start) * 1000)
+    WARMED_UP = True
+    logger.info("TTS warmup_ms=%s", warmup_ms)
+except Exception as ex:  # pragma: no cover
+    logger.warning("TTS warmup failed: %s", ex)
 
 
 def float32_to_wav_bytes(wav_f32: np.ndarray, sr: int) -> tuple[bytes, int]:
@@ -84,9 +150,15 @@ def speak(req: SpeakRequest):
     if not text:
         raise HTTPException(status_code=400, detail="text is required")
     sr = int(req.sample_rate or DEFAULT_SR)
+    long_text = len(text) > 320
+    if long_text:
+        logger.info("long_text chars=%s", len(text))
     try:
+        synth_start = time.perf_counter()
         wav = synthesize(text)
+        synth_ms = int((time.perf_counter() - synth_start) * 1000)
         data, _ = float32_to_wav_bytes(wav, sr)
+        logger.info("synth_ms=%s device=%s", synth_ms, tts.device)
         return Response(content=data, media_type="audio/wav", headers={"Cache-Control": "no-store"})
     except Exception as ex:  # pragma: no cover
         raise HTTPException(status_code=500, detail=str(ex))
@@ -98,8 +170,13 @@ def speak_debug(req: SpeakRequest):
     if not text:
         raise HTTPException(status_code=400, detail="text is required")
     sr = int(req.sample_rate or DEFAULT_SR)
+    long_text = len(text) > 320
+    if long_text:
+        logger.info("long_text chars=%s", len(text))
     try:
+        synth_start = time.perf_counter()
         wav = synthesize(text)
+        synth_ms = int((time.perf_counter() - synth_start) * 1000)
         data, pcm_len = float32_to_wav_bytes(wav, sr)
         duration = float(len(wav) / sr)
         warn = None
@@ -112,6 +189,10 @@ def speak_debug(req: SpeakRequest):
             "sample_rate": sr,
             "duration_sec": duration,
             "pcm_bytes": pcm_len,
+            "device_used": tts.device,
+            "warmup_done": WARMED_UP,
+            "synth_ms": synth_ms,
+            "long_text": long_text,
         }
         if warn:
             resp["warning"] = warn
@@ -122,5 +203,24 @@ def speak_debug(req: SpeakRequest):
 
 @app.get("/health")
 def health():
-    return {"ok": True}
+    return {
+        "ok": True,
+        "device": tts.device,
+        "model": MODEL_ID,
+        "sample_rate": DEFAULT_SR,
+        "torch_version": torch_version,
+        "cuda_available": cuda_avail,
+    }
+
+
+@app.get("/env_debug")
+def env_debug():
+    return {
+        "torch_version": torch_version,
+        "cuda_available": cuda_avail,
+        "cuda_device_count": cuda_count,
+        "current_device": current_device,
+        "device_name": device_name,
+        "device_used": tts.device,
+    }
 


### PR DESCRIPTION
## Summary
- add optional CUDA device selection with env `TTS_DEVICE`
- log torch/cuda diagnostics and warmup the model on startup
- expose diagnostics via `/health`, `/env_debug`, and `/speak_debug`

## Testing
- `python -m py_compile python/tts_server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896fe07b810832990ca0ae83df10d0b