### PR TITLE
feat: stream framed wav chunks

### DIFF
--- a/routes/tts.js
+++ b/routes/tts.js
@@ -148,6 +148,8 @@ router.post('/', async (req, res) => {
     upstream.headers.get('content-type') || 'application/octet-stream'
   );
   res.setHeader('Cache-Control', upstream.headers.get('cache-control') || 'no-store');
+  const framing = upstream.headers.get('x-stream-framing');
+  if (framing) res.setHeader('X-Stream-Framing', framing);
 
   if (stream) {
     // Streaming audio only — do NOT set X-Transcript in streaming mode.


### PR DESCRIPTION
## Summary
- add helper to build WAV headers
- stream length-prefixed mini-WAV frames for chunked TTS
- forward X-Stream-Framing header through Node proxy

## Testing
- `python -m py_compile python/tts_server.py`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68970b6ed2608329b4a62624c9b1da52